### PR TITLE
(code) clear lua module cache in colors/oxocarbon.lua

### DIFF
--- a/colors/oxocarbon.lua
+++ b/colors/oxocarbon.lua
@@ -1,1 +1,3 @@
+-- uncache module to ensure clean reapplication
+package.loaded.oxocarbon = nil
 require [[oxocarbon]]


### PR DESCRIPTION
Lua modules are cached after require, which prevents clean re-application of oxocarbon when swapping *back*, after swapping to another theme. By always un-caching the module we force a reload each time.

Fixes https://github.com/nyoom-engineering/oxocarbon.nvim/issues/38