### PR TITLE
(code) add default StatusLine highlights

### DIFF
--- a/fnl/oxocarbon/init.fnl
+++ b/fnl/oxocarbon/init.fnl
@@ -5,9 +5,9 @@
 ;;     :::::::::::   ::::::::  :   ::::::    :   :::       :   :         :
 ;;     `:::::::::'   `::::::' .'   `:::::   .'   `::.     .'   `.       .'
 ;;       `':::''       `'::'-'       `'::.-'       `':..-'       `-...-'
-;; 
+;;
 ;;   Colorscheme name:    oxocarbon themeing system
-;;   Description:         Neovim Colorschemes based on base16 in fennel made with (hs)luv <3 
+;;   Description:         Neovim Colorschemes based on base16 in fennel made with (hs)luv <3
 ;;   Author:              https://github.com/shaunsingh
 
 (local {: blend-hex} (require :oxocarbon.colorutils))
@@ -49,7 +49,7 @@
 (let! colors_name :oxocarbon)
 (set! termguicolors)
 
-;; oxocarbon palette 
+;; oxocarbon palette
 
 (local base00 "#161616")
 (local base06 "#ffffff")
@@ -93,7 +93,7 @@
                       :blend "#FAFAFA"
                       :none :NONE}))
 
-;; terminal 
+;; terminal
 
 (let! terminal_color_0 oxocarbon.base01)
 (let! terminal_color_1 oxocarbon.base11)
@@ -466,6 +466,10 @@
 (custom-set-face! :TermCursor [] {:fg oxocarbon.base00 :bg oxocarbon.base04})
 (custom-set-face! :TermCursorNC [] {:fg oxocarbon.base00 :bg oxocarbon.base04})
 ;; statusline/winbar
+
+(custom-set-face! :StatusLine [] {:fg oxocarbon.base04 :bg oxocarbon.base00})
+
+(custom-set-face! :StatusLineNC [] {:fg oxocarbon.base04 :bg oxocarbon.base01})
 
 (custom-set-face! :StatusReplace [] {:fg oxocarbon.base00 :bg oxocarbon.base08})
 

--- a/lua/oxocarbon/init.lua
+++ b/lua/oxocarbon/init.lua
@@ -179,6 +179,8 @@ vim.api.nvim_set_hl(0, "FloatBorder", {fg = oxocarbon.blend, bg = oxocarbon.blen
 vim.api.nvim_set_hl(0, "NormalNC", {fg = oxocarbon.base05, bg = oxocarbon.base00})
 vim.api.nvim_set_hl(0, "TermCursor", {fg = oxocarbon.base00, bg = oxocarbon.base04})
 vim.api.nvim_set_hl(0, "TermCursorNC", {fg = oxocarbon.base00, bg = oxocarbon.base04})
+vim.api.nvim_set_hl(0, "StatusLine", {fg = oxocarbon.base04, bg = oxocarbon.base00})
+vim.api.nvim_set_hl(0, "StatusLineNC", {fg = oxocarbon.base04, bg = oxocarbon.base01})
 vim.api.nvim_set_hl(0, "StatusReplace", {fg = oxocarbon.base00, bg = oxocarbon.base08})
 vim.api.nvim_set_hl(0, "StatusInsert", {fg = oxocarbon.base00, bg = oxocarbon.base12})
 vim.api.nvim_set_hl(0, "StatusVisual", {fg = oxocarbon.base00, bg = oxocarbon.base14})


### PR DESCRIPTION
Hi,
I've stumbled upon this colorscheme and seems pretty nice. This PR tries to make the default Statusline more similar to the one in the screenshots.

*Before*
![Screenshot 2023-02-02 at 21 09 37](https://user-images.githubusercontent.com/96259932/216438921-088dee26-a521-4626-811d-3e3ddaf8d7fe.png)

*After*
![Screenshot 2023-02-02 at 21 06 13](https://user-images.githubusercontent.com/96259932/216438153-f64ab72a-3d6b-492d-9233-baa133c637aa.png)
