### PR TITLE
Add Telescope matching highlight

### DIFF
--- a/fnl/oxocarbon/init.fnl
+++ b/fnl/oxocarbon/init.fnl
@@ -476,6 +476,7 @@
 (custom-set-face! :TelescopeResultsTitle [] {:fg oxocarbon.blend :bg oxocarbon.blend})
 (custom-set-face! :TelescopeSelection [] {:fg oxocarbon.none :bg oxocarbon.base02})
 (custom-set-face! :TelescopePreviewLine [] {:fg oxocarbon.none :bg oxocarbon.base01})
+(custom-set-face! :TelescopeMatching [:bold :italic] {:fg oxocarbon.base08 :bg oxocarbon.none})
 
 ;; notify
 

--- a/lua/oxocarbon/init.lua
+++ b/lua/oxocarbon/init.lua
@@ -227,6 +227,7 @@ vim.api.nvim_set_hl(0, "TelescopePromptTitle", {fg = oxocarbon.base02, bg = oxoc
 vim.api.nvim_set_hl(0, "TelescopeResultsTitle", {fg = oxocarbon.blend, bg = oxocarbon.blend})
 vim.api.nvim_set_hl(0, "TelescopeSelection", {fg = oxocarbon.none, bg = oxocarbon.base02})
 vim.api.nvim_set_hl(0, "TelescopePreviewLine", {fg = oxocarbon.none, bg = oxocarbon.base01})
+vim.api.nvim_set_hl(0, "TelescopeMatching", {fg = oxocarbon.base08, bg = oxocarbon.none, italic = true, bold = true})
 vim.api.nvim_set_hl(0, "NotifyERRORBorder", {fg = oxocarbon.base08, bg = oxocarbon.none})
 vim.api.nvim_set_hl(0, "NotifyWARNBorder", {fg = oxocarbon.base15, bg = oxocarbon.none})
 vim.api.nvim_set_hl(0, "NotifyINFOBorder", {fg = oxocarbon.base05, bg = oxocarbon.none})


### PR DESCRIPTION
Currently the Telescope Live grep (and others) does not highlight the search term in the results.
This request highlights in cyan.   

Before:

![Screenshot from 2023-04-23 18-56-29](https://user-images.githubusercontent.com/3412972/233859816-b4ab15e7-746e-430a-a2bd-beddf2d68aca.png)


After:

![Screenshot from 2023-04-23 19-01-41](https://user-images.githubusercontent.com/3412972/233859836-a15b373e-153d-4657-9ced-c51ffc8cb631.png)
