### PR TITLE
add ledger treessitter support

### DIFF
--- a/fnl/oxocarbon/init.fnl
+++ b/fnl/oxocarbon/init.fnl
@@ -161,6 +161,18 @@
 (custom-set-face! :HealthWarning [] {:fg oxocarbon.base14 :bg oxocarbon.none})
 (custom-set-face! :HealthSuccess [] {:fg oxocarbon.base13 :bg oxocarbon.none})
 
+;; ledger
+
+(custom-set-face! "@comment" [] {:link "Comment"})
+(custom-set-face! "@text.literal.commodity" [] {:fg oxocarbon.base13 :bg oxocarbon.none})
+(custom-set-face! "@number" [] {:fg oxocarbon.base09 :bg oxocarbon.none})
+(custom-set-face! "@number.date" [] {:fg oxocarbon.base08 :bg oxocarbon.none})
+(custom-set-face! "@number.date.effective" [] {:fg oxocarbon.base13 :bg oxocarbon.none})
+(custom-set-face! "@number.interval" [] {:fg oxocarbon.base09 :bg oxocarbon.none})
+(custom-set-face! "@number.status" [] {:fg oxocarbon.base12 :bg oxocarbon.none})
+(custom-set-face! "@number.quantity" [] {:fg oxocarbon.base11 :bg oxocarbon.none})
+(custom-set-face! "@number.quantity.negative" [] {:fg oxocarbon.base10 :bg oxocarbon.none})
+
 ;; lsp
 
 (custom-set-face! :LspReferenceText [] {:fg oxocarbon.none :bg oxocarbon.base03})


### PR DESCRIPTION
ledger treesitter support for nyoom ledger mode

(negative numbers will be red and date will be cyan when nvim-treesitter updates their ledger parser!!  

![Screenshot from 2023-05-07 23-12-01](https://user-images.githubusercontent.com/3412972/236707198-148dbbe2-943a-4293-a255-710267dfb1c0.png)
