### PR TITLE
add transparent background guide (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ vim.opt.background = "dark" -- set this to dark or light
 vim.cmd("colorscheme oxocarbon")
 ```
 
+You can also add a transparent background by adding the following lines after `colorscheme`:
+```lua
+vim.api.nvim_set_hl(0, "Normal", { bg = "none" })
+vim.api.nvim_set_hl(0, "NormalFloat", { bg = "none" })
+```
+
 For nyoom.nvim users:
 Nyoom comes bundled with a version of oxocarbon. Enable the `ui.nyoom` module
 


### PR DESCRIPTION
Issues #76 and #58

Adding the following lines inside the README:
```
You can also add a transparent background by adding the following lines after `colorscheme`:
``lua
vim.api.nvim_set_hl(0, "Normal", { bg = "none" })
vim.api.nvim_set_hl(0, "NormalFloat", { bg = "none" })
``
```

Sample representation:
![image](https://github.com/nyoom-engineering/oxocarbon.nvim/assets/107213601/97dd622d-b65b-42ab-afd5-6b30eb908292)
