### PR TITLE
chore: support for hotpot >0.9.0

### DIFF
--- a/make.fnl
+++ b/make.fnl
@@ -1,5 +1,4 @@
 (let [{: build} (require :hotpot.api.make)
-      (oks errs) (build :./fnl {:force? true :atomic? true} "./fnl/(.+)"
-                        (fn [p {: join-path}]
-                          (join-path :./lua p)))]
+      (oks errs) (build :./fnl {:force? true :atomic? true}
+                        [[:**/*.fnl (fn [path] (string.gsub path :fnl :lua))]])]
   (values nil))


### PR DESCRIPTION
Previous `hotpot.api.make` interface was deprecated, see the [changelog](https://github.com/rktjmp/hotpot.nvim/blob/master/CHANGELOG.md#090).