### PR TITLE
docs: add command to remove background color

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ You can also add a transparent background by adding the following lines after `c
 ```lua
 vim.api.nvim_set_hl(0, "Normal", { bg = "none" })
 vim.api.nvim_set_hl(0, "NormalFloat", { bg = "none" })
+vim.api.nvim_set_hl(0, "NormalNC", { bg = "none" })
 ```
 
 For nyoom.nvim users:


### PR DESCRIPTION
I added the command to remove the background from the `NormalNC` highlight that was missing. This highlight takes care of the background color when the main window is not in focus. For example, when we open the telescope float window or when we open the nvim-tree and the main window loses focus.