### PR TITLE
feat: add GitSignsCurrentLineBlame

### DIFF
--- a/fnl/oxocarbon/init.fnl
+++ b/fnl/oxocarbon/init.fnl
@@ -623,6 +623,9 @@
 (custom-set-face! :NeogitHunkHeader [] {:fg oxocarbon.base04 :bg oxocarbon.base02})
 (custom-set-face! :NeogitHunkHeaderHighlight [] {:fg oxocarbon.base04 :bg oxocarbon.base03})
 
+;; gitsigns
+(custom-set-face! :GitSignsCurrentLineBlame [] {:link "Comment" })
+
 ;; hydra
 
 (custom-set-face! :HydraRed [] {:fg oxocarbon.base12 :bg oxocarbon.none})

--- a/lua/oxocarbon/init.lua
+++ b/lua/oxocarbon/init.lua
@@ -10,7 +10,7 @@ local base00 = "#161616"
 local base06 = "#ffffff"
 local base09 = "#78a9ff"
 local oxocarbon = (((vim.o.background == "dark") and {base00 = base00, base01 = blend_hex(base00, base06, 0.085), base02 = blend_hex(base00, base06, 0.18), base03 = blend_hex(base00, base06, 0.3), base04 = blend_hex(base00, base06, 0.82), base05 = blend_hex(base00, base06, 0.95), base06 = base06, base07 = "#08bdba", base08 = "#3ddbd9", base09 = base09, base10 = "#ee5396", base11 = "#33b1ff", base12 = "#ff7eb6", base13 = "#42be65", base14 = "#be95ff", base15 = "#82cfff", blend = "#131313", none = "NONE"}) or {base00 = base06, base01 = blend_hex(base00, base06, 0.95), base02 = blend_hex(base00, base06, 0.82), base03 = base00, base04 = "#37474F", base05 = "#90A4AE", base06 = "#525252", base07 = "#08bdba", base08 = "#ff7eb6", base09 = "#ee5396", base10 = "#FF6F00", base11 = "#0f62fe", base12 = "#673AB7", base13 = "#42be65", base14 = "#be95ff", base15 = "#FFAB91", blend = "#FAFAFA", none = "NONE"})
-do end (vim.g)["terminal_color_0"] = oxocarbon.base01
+vim.g["terminal_color_0"] = oxocarbon.base01
 vim.g["terminal_color_1"] = oxocarbon.base11
 vim.g["terminal_color_2"] = oxocarbon.base14
 vim.g["terminal_color_3"] = oxocarbon.base13
@@ -348,6 +348,7 @@ vim.api.nvim_set_hl(0, "NeogitBranch", {fg = oxocarbon.base10, bg = oxocarbon.no
 vim.api.nvim_set_hl(0, "NeogitRemote", {fg = oxocarbon.base09, bg = oxocarbon.none})
 vim.api.nvim_set_hl(0, "NeogitHunkHeader", {fg = oxocarbon.base04, bg = oxocarbon.base02})
 vim.api.nvim_set_hl(0, "NeogitHunkHeaderHighlight", {fg = oxocarbon.base04, bg = oxocarbon.base03})
+vim.api.nvim_set_hl(0, "GitSignsCurrentLineBlame", {link = "Comment"})
 vim.api.nvim_set_hl(0, "HydraRed", {fg = oxocarbon.base12, bg = oxocarbon.none})
 vim.api.nvim_set_hl(0, "HydraBlue", {fg = oxocarbon.base09, bg = oxocarbon.none})
 vim.api.nvim_set_hl(0, "HydraAmaranth", {fg = oxocarbon.base10, bg = oxocarbon.none})


### PR DESCRIPTION
This adds comment highlighting for [GitSignsCurrentLineBlame](https://github.com/lewis6991/gitsigns.nvim/blob/4daf7022f1481edf1e8fb9947df13bb07c18e89a/doc/gitsigns.txt#L1099-L1103).

**Before:**
<img width="921" alt="oxoxcarbon git signs - before" src="https://github.com/user-attachments/assets/924972cc-ffee-4be6-afc7-46351667caaa">
Note the current line blame currently defaults to `NonText`, and is quite unreadable / difficult to notice.

**After:**
<img width="930" alt="oxoxcarbon git signs - after" src="https://github.com/user-attachments/assets/2a6b45f0-4f83-4086-9881-e4aa61d0559c">
With the changes it makes the current line blame have the same styling as a code comment, making it more readable.

If this was intentional / you think it's better to leave it as `NonText` by default, I can close this.

Note also some of the fennel -> lua compilation was a little bit different and removed a `do end` - perhaps the version of hotpot I'm using may be newer?