### PR TITLE
fix: map @tag.builtin.tsx to @tag.tsx for builtin tags on tsx

### DIFF
--- a/fnl/oxocarbon/init.fnl
+++ b/fnl/oxocarbon/init.fnl
@@ -488,6 +488,7 @@
 (custom-set-face! "@tag" [] {:fg oxocarbon.base09 :bg oxocarbon.none})
 (custom-set-face! "@tag.attribute" [] {:fg oxocarbon.base15 :bg oxocarbon.none})
 (custom-set-face! "@tag.delimiter" [] {:fg oxocarbon.base15 :bg oxocarbon.none})
+(custom-set-face! "@tag.builtin.tsx" [] {:link "@tag.tsx"})
 
 ;;; Conceal
 ;; @conceal

--- a/lua/oxocarbon/init.lua
+++ b/lua/oxocarbon/init.lua
@@ -10,7 +10,7 @@ local base00 = "#161616"
 local base06 = "#ffffff"
 local base09 = "#78a9ff"
 local oxocarbon = (((vim.o.background == "dark") and {base00 = base00, base01 = blend_hex(base00, base06, 0.085), base02 = blend_hex(base00, base06, 0.18), base03 = blend_hex(base00, base06, 0.3), base04 = blend_hex(base00, base06, 0.82), base05 = blend_hex(base00, base06, 0.95), base06 = base06, base07 = "#08bdba", base08 = "#3ddbd9", base09 = base09, base10 = "#ee5396", base11 = "#33b1ff", base12 = "#ff7eb6", base13 = "#42be65", base14 = "#be95ff", base15 = "#82cfff", blend = "#131313", none = "NONE"}) or {base00 = base06, base01 = blend_hex(base00, base06, 0.95), base02 = blend_hex(base00, base06, 0.82), base03 = base00, base04 = "#37474F", base05 = "#90A4AE", base06 = "#525252", base07 = "#08bdba", base08 = "#ff7eb6", base09 = "#ee5396", base10 = "#FF6F00", base11 = "#0f62fe", base12 = "#673AB7", base13 = "#42be65", base14 = "#be95ff", base15 = "#FFAB91", blend = "#FAFAFA", none = "NONE"})
-do end (vim.g)["terminal_color_0"] = oxocarbon.base01
+vim.g["terminal_color_0"] = oxocarbon.base01
 vim.g["terminal_color_1"] = oxocarbon.base11
 vim.g["terminal_color_2"] = oxocarbon.base14
 vim.g["terminal_color_3"] = oxocarbon.base13
@@ -264,6 +264,7 @@ vim.api.nvim_set_hl(0, "@text.uri", {fg = oxocarbon.base14, bg = oxocarbon.none,
 vim.api.nvim_set_hl(0, "@tag", {fg = oxocarbon.base09, bg = oxocarbon.none})
 vim.api.nvim_set_hl(0, "@tag.attribute", {fg = oxocarbon.base15, bg = oxocarbon.none})
 vim.api.nvim_set_hl(0, "@tag.delimiter", {fg = oxocarbon.base15, bg = oxocarbon.none})
+vim.api.nvim_set_hl(0, "@tag.builtin.tsx", {link = "@tag.tsx"})
 vim.api.nvim_set_hl(0, "@reference", {fg = oxocarbon.base04, bg = oxocarbon.none})
 vim.api.nvim_set_hl(0, "NvimInternalError", {fg = oxocarbon.base00, bg = oxocarbon.base08})
 vim.api.nvim_set_hl(0, "NormalFloat", {fg = oxocarbon.base05, bg = oxocarbon.blend})


### PR DESCRIPTION

Added map @tag.builtin.tsx to @tag.tsx for builtin tags on tsx because builtin tags are not highlighted since `@tag.builtin.tsx` hl is missing.

## before 
![Screenshot 2024-11-11 at 6 52 40 PM](https://github.com/user-attachments/assets/3b4ed0d0-a68d-4ba3-a9e8-40f1d0f191bd)

## after 
![Screenshot 2024-11-11 at 7 43 13 PM](https://github.com/user-attachments/assets/19b99569-0a1f-4b4c-b6b1-e951d8926833)

The highlight refers to this PR (https://github.com/nyoom-engineering/oxocarbon.nvim/issues/46) .

