### PR TITLE
feat: add flash.nvim fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The colorscheme explicitly adds highlights for the following plugins:
 - Neogit
 - Gitsigns
 - Hydra
+- Flash
 
 And many others should "just work!" If you have a plugin that needs explicit highlights, feel free to open an issue or PR and I would be happy to add them.  
 

--- a/fnl/oxocarbon/init.fnl
+++ b/fnl/oxocarbon/init.fnl
@@ -720,4 +720,8 @@
 (custom-set-face! :VimwikiLink [] {:link "markdownUrl"})
 (custom-set-face! :VimwikiCode [] {:link "markdownCode"})
 
+;; flash
+
+(custom-set-face! :FlashLabel [:bold] {:fg oxocarbon.base05 :bg oxocarbon.base00})
+
 { : oxocarbon }

--- a/lua/oxocarbon/init.lua
+++ b/lua/oxocarbon/init.lua
@@ -415,4 +415,5 @@ vim.api.nvim_set_hl(0, "VimwikiHeaderChar", {link = "markdownH1"})
 vim.api.nvim_set_hl(0, "VimwikiList", {link = "markdownListMarker"})
 vim.api.nvim_set_hl(0, "VimwikiLink", {link = "markdownUrl"})
 vim.api.nvim_set_hl(0, "VimwikiCode", {link = "markdownCode"})
+vim.api.nvim_set_hl(0, "FlashLabel", {fg = oxocarbon.base05, bg = oxocarbon.base00, bold = true})
 return {oxocarbon = oxocarbon}


### PR DESCRIPTION
Small addition of flash label highlight as currently the plugin is pretty unusable 

I like this minimalistic bold white label, but I'm open to other ideas too

Before:
<img width="1344" height="473" alt="SCR-20250820-kbdd" src="https://github.com/user-attachments/assets/54901dfb-23bd-4060-9412-eb2bcdc0dcdc" />

After:
<img width="1326" height="464" alt="SCR-20250820-kebo" src="https://github.com/user-attachments/assets/fe474992-c82f-4788-8d91-0f43aefad21a" />
